### PR TITLE
README.md: make installation commands directly runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ code from GitHub.
 
 To build with Autotools (Autoconf and Automake) on GNU/Linux, OSX, or Windows 10 WSL,
 ```
-    $ git clone https://github.com/universal-ctags/ctags.git
-    $ cd ctags
-    $ ./autogen.sh
-    $ ./configure --prefix=/where/you/want # defaults to /usr/local
-    $ make
-    $ make install # may require extra privileges depending on where to install
+git clone https://github.com/universal-ctags/ctags.git
+cd ctags
+./autogen.sh
+./configure  # use --prefix=/where/you/want to override installation directory, defaults to /usr/local
+make
+make install # may require extra privileges depending on where to install
 ```
 
 GNU make is assumed as the `make` command.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To build with Autotools (Autoconf and Automake) on GNU/Linux, OSX, or Windows 10
 git clone https://github.com/universal-ctags/ctags.git
 cd ctags
 ./autogen.sh
-./configure  # use --prefix=/where/you/want to override installation directory, defaults to /usr/local ??? another change
+./configure  # use --prefix=/where/you/want to override installation directory, defaults to /usr/local ??? another change blabla
 make
 make install # may require extra privileges depending on where to install
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To build with Autotools (Autoconf and Automake) on GNU/Linux, OSX, or Windows 10
 git clone https://github.com/universal-ctags/ctags.git
 cd ctags
 ./autogen.sh
-./configure  # use --prefix=/where/you/want to override installation directory, defaults to /usr/local ???
+./configure  # use --prefix=/where/you/want to override installation directory, defaults to /usr/local ??? another change
 make
 make install # may require extra privileges depending on where to install
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To build with Autotools (Autoconf and Automake) on GNU/Linux, OSX, or Windows 10
 git clone https://github.com/universal-ctags/ctags.git
 cd ctags
 ./autogen.sh
-./configure  # use --prefix=/where/you/want to override installation directory, defaults to /usr/local
+./configure  # use --prefix=/where/you/want to override installation directory, defaults to /usr/local ???
 make
 make install # may require extra privileges depending on where to install
 ```


### PR DESCRIPTION
Allow users to directly copy and run the installation commands.